### PR TITLE
[southeast-asia] Auto-block: Add 5 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -2,3 +2,8 @@
 103.26.246.133 # Too many spam requests
 135.125.149.125 # Auto-blocked [Germany/AS16276] B:0 M:16331 (2025-11-26 12:36:46 UTC)
 202.4.96.159 # Auto-blocked [Bangladesh/AS23956] B:265 M:10759 (2025-11-26 12:36:46 UTC)
+193.119.80.64 # Auto-blocked [Australia/AS7545] B:4476 M:15 (2025-11-27 02:07:32 UTC)
+103.178.32.98 # Auto-blocked [Bangladesh/AS149293] B:0 M:4346 (2025-11-27 02:07:32 UTC)
+103.214.201.66 # Auto-blocked [Bangladesh/AS135341] B:1814 M:394 (2025-11-27 02:07:32 UTC)
+103.121.223.49 # Auto-blocked [Bangladesh/AS138171] B:1246 M:5 (2025-11-27 02:07:32 UTC)
+51.195.60.99 # Auto-blocked [Germany/AS16276] B:0 M:563 (2025-11-27 02:07:32 UTC)


### PR DESCRIPTION
## Auto-Block Report

**Date:** 2025-11-27 02:07:32 UTC
**New IPs to Block:** 5

### New Malicious IPs to Block

- **193.119.80.64** [Australia/AS7545]
  - Blocked queries: 4476
  - Malicious queries: 15
  - Top malicious domains: config.nos-avg.cz

- **103.178.32.98** [Bangladesh/AS149293]
  - Blocked queries: 0
  - Malicious queries: 4346
  - Top malicious domains: czararoadb.xyz, czarabloger.xyz, blowechnellvpn.xyz

- **103.214.201.66** [Bangladesh/AS135341]
  - Blocked queries: 1814
  - Malicious queries: 394
  - Top malicious domains: tracker.internetwarriors.net, asdxwqw.com, open.stealth.si

- **103.121.223.49** [Bangladesh/AS138171]
  - Blocked queries: 1246
  - Malicious queries: 5
  - Top malicious domains: config.nos.avast.com

- **51.195.60.99** [Germany/AS16276]
  - Blocked queries: 0
  - Malicious queries: 563
  - Top malicious domains: us.gov, k0rx.com


---
🤖 Auto-generated by Central Malicious IP Monitor

**Next Steps:**
1. Review the IPs and their activity
2. Merge this PR to apply blocks
3. Run `bash manage_ip_lists.sh --kahf-only` on nodes to sync
