### PR TITLE
[bdix] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -21,3 +21,5 @@
 31.57.12.118 # Auto-blocked [Brazil/AS213613] B:0 M:107 (2025-11-29 05:25:47 UTC)
 90.188.247.33 # Auto-blocked [Russia/AS12389] B:0 M:104 (2025-11-29 05:25:47 UTC)
 185.185.135.28 # Auto-blocked [Israel/AS206446] B:0 M:100 (2025-11-29 05:25:47 UTC)
+116.202.115.110 # Auto-blocked [Germany/AS24940] B:0 M:883 (2025-11-29 21:28:07 UTC)
+178.89.128.128 # Auto-blocked [Kazakhstan/AS9198] B:0 M:491 (2025-11-29 21:28:07 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-11-29 21:28:07 UTC

## 📊 Executive Summary

**Date:** 2025-11-29 21:28:07 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,374
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Germany | 1 | 50.0% |
| Kazakhstan | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS24940 (Hetzner Online GmbH) | 1 | 50.0% |
| AS9198 (JSC Kazakhtelecom) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,374
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 687.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 924 |
| `k0rx.com` | 450 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **90.188.247.33** [Russia/AS12389] - 104 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 116.202.115.110 [Germany/AS24940]

- **Location:** Falkenstein, Germany
- **ISP:** Hetzner Online GmbH
- **Blocked queries:** 0
- **Malicious queries:** 883
- **Detected on nodes:** dns-frontend-new-02, dns-frontend-new-01
- **Top malicious domains:** `ncca.mil` (598), `k0rx.com` (285)

### 178.89.128.128 [Kazakhstan/AS9198]

- **Location:** Kokshetau, Kazakhstan
- **ISP:** JSC Kazakhtelecom
- **Blocked queries:** 0
- **Malicious queries:** 491
- **Detected on nodes:** dns-frontend-new-02, dns-frontend-new-01
- **Top malicious domains:** `ncca.mil` (326), `k0rx.com` (165)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,858 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
