### PR TITLE
[bdix] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -25,3 +25,5 @@
 178.89.128.128 # Auto-blocked [Kazakhstan/AS9198] B:0 M:491 (2025-11-30 00:28:50 UTC)
 45.147.78.66 # Auto-blocked [Unknown/Unknown] B:0 M:519 (2025-12-01 16:36:58 UTC)
 87.120.167.193 # Auto-blocked [Unknown/Unknown] B:0 M:440 (2025-12-01 16:36:58 UTC)
+222.219.232.130 # Auto-blocked [China/AS4134] B:0 M:1727 (2025-12-02 04:40:47 UTC)
+222.219.232.134 # Auto-blocked [China/AS4134] B:0 M:245 (2025-12-02 04:40:47 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-02 04:40:47 UTC

## 📊 Executive Summary

**Date:** 2025-12-02 04:40:47 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,972
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| China | 2 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS4134 (Chinanet) | 2 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,972
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 986.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 1,167 |
| `k0rx.com` | 805 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **45.147.78.66** [Iran/AS51889] - 519 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 222.219.232.130 [China/AS4134]

- **Location:** Kunming, China
- **ISP:** Chinanet
- **Blocked queries:** 0
- **Malicious queries:** 1,727
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (1,001), `k0rx.com` (726)

### 222.219.232.134 [China/AS4134]

- **Location:** Kunming, China
- **ISP:** Chinanet
- **Blocked queries:** 0
- **Malicious queries:** 245
- **Detected on nodes:** dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (166), `k0rx.com` (79)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,717 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
