### PR TITLE
[bdix] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -27,3 +27,5 @@
 87.120.167.193 # Auto-blocked [Unknown/Unknown] B:0 M:440 (2025-12-01 16:36:58 UTC)
 222.219.232.130 # Auto-blocked [China/AS4134] B:0 M:1727 (2025-12-02 06:41:21 UTC)
 222.219.232.134 # Auto-blocked [China/AS4134] B:0 M:245 (2025-12-02 06:41:21 UTC)
+103.116.52.79 # Auto-blocked [Vietnam/AS150895] B:0 M:707 (2025-12-02 16:44:30 UTC)
+188.225.49.156 # Auto-blocked [Russia/AS28840] B:0 M:300 (2025-12-02 16:44:30 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-02 16:44:30 UTC

## 📊 Executive Summary

**Date:** 2025-12-02 16:44:30 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,007
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 2 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Vietnam | 1 | 50.0% |
| Russia | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS150895 (CMINH) | 1 | 50.0% |
| AS28840 (PJSC "TATTELECOM") | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,007
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 503.5
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 646 |
| `k0rx.com` | 361 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **222.219.232.130** [China/AS4134] - 1727 malicious queries
- **222.219.232.134** [China/AS4134] - 245 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 103.116.52.79 [Vietnam/AS150895]

- **Location:** Quận Tân Phú, Vietnam
- **ISP:** CMINH
- **Blocked queries:** 0
- **Malicious queries:** 707
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (457), `k0rx.com` (250)

### 188.225.49.156 [Russia/AS28840]

- **Location:** Kazan', Russia
- **ISP:** PJSC "TATTELECOM"
- **Blocked queries:** 0
- **Malicious queries:** 300
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (189), `k0rx.com` (111)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,880 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
