### PR TITLE
[bdix] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -36,3 +36,5 @@
 128.116.54.33 # Auto-blocked [United States/AS22697] B:0 M:215 (2025-12-05 15:00:30 UTC)
 103.116.52.79 # Auto-blocked [Vietnam/AS150895] B:0 M:107 (2025-12-05 15:00:30 UTC)
 94.183.183.52 # Auto-blocked [United States/AS56971] B:0 M:100 (2025-12-05 15:00:30 UTC)
+194.116.214.179 # Auto-blocked [France/AS56971] B:0 M:218 (2025-12-06 05:02:32 UTC)
+91.124.63.37 # Auto-blocked [Türkiye/AS209474] B:0 M:109 (2025-12-06 05:02:32 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-06 05:02:32 UTC

## 📊 Executive Summary

**Date:** 2025-12-06 05:02:32 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 327
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 6 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| France | 1 | 50.0% |
| Türkiye | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS56971 (CGI GLOBAL LIMITED) | 1 | 50.0% |
| AS209474 (Ekiphost Bilisim Teknolojileri) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 327
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 163.5
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 227 |
| `k0rx.com` | 100 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **82.25.42.31** [Germany/AS215039] - 555 malicious queries
- **104.210.130.182** [United States/AS8075] - 434 malicious queries
- **128.116.46.33** [Singapore/AS22697] - 341 malicious queries
- **128.116.54.33** [United States/AS22697] - 215 malicious queries
- **103.116.52.79** [Vietnam/AS150895] - 107 malicious queries
- **94.183.183.52** [United States/AS56971] - 100 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 91.124.63.37 [Türkiye/AS209474]

- **Location:** Istanbul, Türkiye
- **ISP:** Ekiphost Bilisim Teknolojileri Ticaret VE Sanayi Limited Sirketi
- **Blocked queries:** 0
- **Malicious queries:** 109
- **Detected on nodes:** dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (75), `k0rx.com` (34)

### 194.116.214.179 [France/AS56971]

- **Location:** Paris, France
- **ISP:** CGI GLOBAL LIMITED
- **Blocked queries:** 0
- **Malicious queries:** 218
- **Detected on nodes:** dns-frontend-new-02, dns-frontend-new-01
- **Top malicious domains:** `ncca.mil` (152), `k0rx.com` (66)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,203 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
