### PR TITLE
[bdix] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -47,3 +47,5 @@
 15.235.160.67 # Auto-blocked [Singapore/AS16276] B:0 M:332 (2025-12-07 12:12:13 UTC)
 85.190.160.209 # Auto-blocked [Germany/AS199610] B:0 M:250 (2025-12-07 12:12:13 UTC)
 68.148.20.85 # Auto-blocked [Canada/AS6327] B:0 M:244 (2025-12-07 12:12:13 UTC)
+193.22.129.17 # Auto-blocked [France/AS215140] B:0 M:866 (2025-12-07 22:14:29 UTC)
+77.65.122.125 # Auto-blocked [Poland/AS13110] B:0 M:298 (2025-12-07 22:14:29 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-07 22:14:29 UTC

## 📊 Executive Summary

**Date:** 2025-12-07 22:14:29 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,164
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 9 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| France | 1 | 50.0% |
| Poland | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS215140 (Lucas ANSQUER) | 1 | 50.0% |
| AS13110 (INEA sp. z o.o.) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,164
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 582.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 776 |
| `k0rx.com` | 388 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **45.117.165.177** [Vietnam/AS135918] - 1827 malicious queries
- **185.248.101.137** [Russia/AS44812] - 383 malicious queries
- **103.212.227.249** [Australia/AS137409] - 382 malicious queries
- **188.191.107.12** [Türkiye/AS215238] - 351 malicious queries
- **50.7.22.221** [The Netherlands/AS30058] - 349 malicious queries
- **15.235.181.54** [Singapore/AS16276] - 341 malicious queries
- **15.235.160.67** [Singapore/AS16276] - 332 malicious queries
- **85.190.160.209** [Germany/AS199610] - 250 malicious queries
- **68.148.20.85** [Canada/AS6327] - 244 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 77.65.122.125 [Poland/AS13110]

- **Location:** Baranów, Poland
- **ISP:** INEA sp. z o.o.
- **Blocked queries:** 0
- **Malicious queries:** 298
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (198), `k0rx.com` (100)

### 193.22.129.17 [France/AS215140]

- **Location:** Paris, France
- **ISP:** Lucas ANSQUER
- **Blocked queries:** 0
- **Malicious queries:** 866
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (578), `k0rx.com` (288)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,337 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
