### PR TITLE
[bdix] Auto-block: Add 5 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -47,3 +47,8 @@
 15.235.160.67 # Auto-blocked [Singapore/AS16276] B:0 M:332 (2025-12-07 12:12:13 UTC)
 85.190.160.209 # Auto-blocked [Germany/AS199610] B:0 M:250 (2025-12-07 12:12:13 UTC)
 68.148.20.85 # Auto-blocked [Canada/AS6327] B:0 M:244 (2025-12-07 12:12:13 UTC)
+103.118.76.122 # Auto-blocked [Bangladesh/AS137959] B:1386 M:1 (2025-12-08 08:17:26 UTC)
+193.22.129.17 # Auto-blocked [France/AS215140] B:0 M:866 (2025-12-08 08:17:26 UTC)
+82.25.42.230 # Auto-blocked [Germany/AS215039] B:0 M:426 (2025-12-08 08:17:26 UTC)
+45.117.165.241 # Auto-blocked [Vietnam/AS135918] B:0 M:416 (2025-12-08 08:17:26 UTC)
+77.65.122.125 # Auto-blocked [Poland/AS13110] B:0 M:298 (2025-12-08 08:17:26 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-08 08:17:26 UTC

## 📊 Executive Summary

**Date:** 2025-12-08 08:17:26 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 5
**Total Blocked Queries:** 1,386
**Total Malicious Queries:** 2,007
**CIDR Pattern Analysis:** 5 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 5
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 4 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Bangladesh | 1 | 20.0% |
| France | 1 | 20.0% |
| Germany | 1 | 20.0% |
| Vietnam | 1 | 20.0% |
| Poland | 1 | 20.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS137959 (Vision Technologies Ltd) | 1 | 20.0% |
| AS215140 (Lucas ANSQUER) | 1 | 20.0% |
| AS215039 (Nodesty LLC) | 1 | 20.0% |
| AS135918 (ODSJSC) | 1 | 20.0% |
| AS13110 (INEA sp. z o.o.) | 1 | 20.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 1,386
- **Total Malicious Queries:** 2,007
- **Average Blocked/IP:** 277.2
- **Average Malicious/IP:** 401.4
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `telemetry.sdk.inmobi.com` | 100 |
| `googleads.g.doubleclick.net` | 96 |
| `config.inmobi.com` | 72 |
| `rt.applovin.com` | 62 |
| `sdkconfig.ad.intl.xiaomi.com` | 58 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 1,332 |
| `k0rx.com` | 674 |
| `push.apple.com` | 1 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **45.117.165.177** [Vietnam/AS135918] - 685 malicious queries
- **185.248.101.137** [Russia/AS44812] - 383 malicious queries
- **15.235.181.54** [Singapore/AS16276] - 341 malicious queries
- **85.190.160.209** [Germany/AS199610] - 250 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 45.117.165.241 [Vietnam/AS135918]

- **Location:** Quận Tân Phú, Vietnam
- **ISP:** ODSJSC
- **Blocked queries:** 0
- **Malicious queries:** 416
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (273), `k0rx.com` (143)

### 77.65.122.125 [Poland/AS13110]

- **Location:** Baranów, Poland
- **ISP:** INEA sp. z o.o.
- **Blocked queries:** 0
- **Malicious queries:** 298
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (198), `k0rx.com` (100)

### 82.25.42.230 [Germany/AS215039]

- **Location:** Frankfurt am Main, Germany
- **ISP:** Nodesty LLC
- **Blocked queries:** 0
- **Malicious queries:** 426
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (283), `k0rx.com` (143)

### 103.118.76.122 [Bangladesh/AS137959]

- **Location:** Pābna, Bangladesh
- **ISP:** Vision Technologies Ltd
- **Blocked queries:** 1,386
- **Malicious queries:** 1
- **Detected on nodes:** dns-frontend-new-01
- **Top blocked domains:** `telemetry.sdk.inmobi.com` (100), `googleads.g.doubleclick.net` (96), `config.inmobi.com` (72), `rt.applovin.com` (62), `sdkconfig.ad.intl.xiaomi.com` (58)
- **Top malicious domains:** `push.apple.com` (1)

### 193.22.129.17 [France/AS215140]

- **Location:** Paris, France
- **ISP:** Lucas ANSQUER
- **Blocked queries:** 0
- **Malicious queries:** 866
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (578), `k0rx.com` (288)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 4,536 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
