### PR TITLE
[bdix] Auto-block: Add 5 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -47,3 +47,8 @@
 15.235.160.67 # Auto-blocked [Singapore/AS16276] B:0 M:332 (2025-12-07 12:12:13 UTC)
 85.190.160.209 # Auto-blocked [Germany/AS199610] B:0 M:250 (2025-12-07 12:12:13 UTC)
 68.148.20.85 # Auto-blocked [Canada/AS6327] B:0 M:244 (2025-12-07 12:12:13 UTC)
+103.179.62.171 # Auto-blocked [Bangladesh/AS10075] B:0 M:1552 (2025-12-09 16:25:05 UTC)
+203.177.94.134 # Auto-blocked [Philippines/AS4775] B:0 M:464 (2025-12-09 16:25:05 UTC)
+221.154.141.33 # Auto-blocked [South Korea/AS4766] B:0 M:306 (2025-12-09 16:25:05 UTC)
+38.76.247.36 # Auto-blocked [Singapore/AS136510] B:0 M:251 (2025-12-09 16:25:05 UTC)
+211.245.97.51 # Auto-blocked [South Korea/AS9318] B:0 M:104 (2025-12-09 16:25:05 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-09 16:25:05 UTC

## 📊 Executive Summary

**Date:** 2025-12-09 16:25:05 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 5
**Total Blocked Queries:** 0
**Total Malicious Queries:** 2,677
**CIDR Pattern Analysis:** 5 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 5
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| South Korea | 2 | 40.0% |
| Bangladesh | 1 | 20.0% |
| Philippines | 1 | 20.0% |
| Singapore | 1 | 20.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS10075 (Fiber@Home Global Limited) | 1 | 20.0% |
| AS4775 (Globe Telecom) | 1 | 20.0% |
| AS4766 (Korea Telecom) | 1 | 20.0% |
| AS136510 (Cogent Communications) | 1 | 20.0% |
| AS9318 (SK Broadband Co Ltd) | 1 | 20.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 2,677
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 535.4
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 1,786 |
| `k0rx.com` | 891 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 38.76.247.36 [Singapore/AS136510]

- **Location:** Singapore, Singapore
- **ISP:** Cogent Communications
- **Blocked queries:** 0
- **Malicious queries:** 251
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (166), `k0rx.com` (85)

### 103.179.62.171 [Bangladesh/AS10075]

- **Location:** Dhaka, Bangladesh
- **ISP:** Fiber@Home Global Limited
- **Blocked queries:** 0
- **Malicious queries:** 1,552
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (1,035), `k0rx.com` (517)

### 203.177.94.134 [Philippines/AS4775]

- **Location:** Manila, Philippines
- **ISP:** Globe Telecom
- **Blocked queries:** 0
- **Malicious queries:** 464
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (315), `k0rx.com` (149)

### 211.245.97.51 [South Korea/AS9318]

- **Location:** Jung-gu, South Korea
- **ISP:** SK Broadband Co Ltd
- **Blocked queries:** 0
- **Malicious queries:** 104
- **Detected on nodes:** dns-frontend-new-01
- **Top malicious domains:** `ncca.mil` (66), `k0rx.com` (38)

### 221.154.141.33 [South Korea/AS4766]

- **Location:** Incheon, South Korea
- **ISP:** Korea Telecom
- **Blocked queries:** 0
- **Malicious queries:** 306
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (204), `k0rx.com` (102)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,437 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
