### PR TITLE
[bdix] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -53,3 +53,4 @@
 81.41.168.20 # Auto-blocked [Spain/AS3352] B:0 M:255 (2025-12-10 00:25:56 UTC)
 38.76.247.36 # Auto-blocked [Singapore/AS136510] B:0 M:251 (2025-12-10 00:25:56 UTC)
 211.245.97.51 # Auto-blocked [South Korea/AS9318] B:0 M:104 (2025-12-10 00:25:56 UTC)
+118.32.105.50 # Auto-blocked [South Korea/AS4766] B:0 M:234 (2025-12-10 09:41:53 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-10 09:41:53 UTC

## 📊 Executive Summary

**Date:** 2025-12-10 09:41:53 UTC
**Analysis Coverage:** 3/3 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 0
**Total Malicious Queries:** 234
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 6 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| South Korea | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS4766 (Korea Telecom) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 234
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 234.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `ncca.mil` | 155 |
| `k0rx.com` | 79 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **203.177.94.134** [Philippines/AS4775] - 464 malicious queries
- **104.167.27.10** [Iran/AS216067] - 341 malicious queries
- **221.154.141.33** [South Korea/AS4766] - 306 malicious queries
- **81.41.168.20** [Spain/AS3352] - 255 malicious queries
- **38.76.247.36** [Singapore/AS136510] - 251 malicious queries
- **211.245.97.51** [South Korea/AS9318] - 104 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 118.32.105.50 [South Korea/AS4766]

- **Location:** Nowon-gu, South Korea
- **ISP:** Korea Telecom
- **Blocked queries:** 0
- **Malicious queries:** 234
- **Detected on nodes:** dns-frontend-new-01, dns-frontend-new-02
- **Top malicious domains:** `ncca.mil` (155), `k0rx.com` (79)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,803 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 100
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 3/3
- **Region:** bdix
