### PR TITLE
[southeastasia] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -63,3 +63,4 @@
 91.124.63.37 # Auto-blocked [Türkiye/AS209474] B:0 M:396 (2025-12-10 16:53:20 UTC)
 121.141.69.122 # Auto-blocked [South Korea/AS4766] B:0 M:373 (2025-12-10 16:53:20 UTC)
 
+110.76.128.235 # Auto-blocked [Bangladesh/AS59362] B:0 M:254 (2025-12-10 17:03:49 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-10 17:03:49 UTC

## 📊 Executive Summary

**Date:** 2025-12-10 17:03:49 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 0
**Total Malicious Queries:** 254
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Bangladesh | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS59362 (KS Network Limited) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 254
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 254.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `asdxwqw.com` | 5 |
| `1337.abcvg.info` | 5 |
| `bittorrent-tracker.e-n-c-r-y-p-t.net` | 5 |
| `bvarf.tracker.sh` | 5 |
| `ch3oh.ru` | 5 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **222.219.232.130** [China/AS4134] - 257 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 110.76.128.235 [Bangladesh/AS59362]

- **Location:** Barishal, Bangladesh
- **ISP:** KS Network Limited
- **Blocked queries:** 0
- **Malicious queries:** 254
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `asdxwqw.com` (5), `1337.abcvg.info` (5), `bittorrent-tracker.e-n-c-r-y-p-t.net` (5), `bvarf.tracker.sh` (5), `ch3oh.ru` (5)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,670 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** southeastasia
