### PR TITLE
[southeastasia] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -92,3 +92,4 @@
 156.214.108.152 # Auto-blocked [Egypt/AS8452] B:502 M:4154 (2025-12-23 17:21:38 UTC)
 171.225.223.108 # Auto-blocked [Vietnam/AS7552] B:0 M:406 (2025-12-23 17:21:38 UTC)
 80.246.94.157 # Auto-blocked [Russia/AS21378] B:0 M:310 (2025-12-23 17:21:38 UTC)
+70.168.144.122 # Auto-blocked [United States/AS22773] B:0 M:630 (2025-12-24 01:10:23 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-24 01:10:23 UTC

## 📊 Executive Summary

**Date:** 2025-12-24 01:10:23 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 0
**Total Malicious Queries:** 630
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United States | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS22773 (Cox Communications Inc.) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 630
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 630.0
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `.` | 400 |
| `namecheap.com` | 200 |
| `exploit.bot` | 30 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **103.178.32.100** [Bangladesh/AS149293] - 1066 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 70.168.144.122 [United States/AS22773]

- **Location:** Lake Forest, United States
- **ISP:** Cox Communications Inc.
- **Blocked queries:** 0
- **Malicious queries:** 630
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `.` (400), `namecheap.com` (200), `exploit.bot` (30)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,549 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 1,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** southeastasia
