### PR TITLE
[uksouth] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,4 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+90.252.125.100 # Auto-blocked [United Kingdom/AS5378] B:297 M:5652 (2025-12-28 14:26:41 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-28 14:26:41 UTC

## 📊 Executive Summary

**Date:** 2025-12-28 14:26:41 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 297
**Total Malicious Queries:** 5,652
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (Energis UK) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 297
- **Total Malicious Queries:** 5,652
- **Average Blocked/IP:** 297.0
- **Average Malicious/IP:** 5,652.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `pagead2.googlesyndication.com` | 54 |
| `region1.google-analytics.com` | 42 |
| `_dns.resolver.arpa` | 31 |
| `dns.google` | 21 |
| `securepubads.g.doubleclick.net` | 18 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 5,652 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 90.252.125.100 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 297
- **Malicious queries:** 5,652
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `pagead2.googlesyndication.com` (54), `region1.google-analytics.com` (42), `_dns.resolver.arpa` (31), `dns.google` (21), `securepubads.g.doubleclick.net` (18)
- **Top malicious domains:** `debug.opendns.com` (5,652)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,457 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
