### PR TITLE
[uksouth] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,5 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+90.252.125.100 # Auto-blocked [United Kingdom/AS5378] B:160 M:7003 (2025-12-31 14:25:52 UTC)
+156.222.227.198 # Auto-blocked [Egypt/AS8452] B:347 M:5832 (2025-12-31 14:25:52 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2025-12-31 14:25:52 UTC

## 📊 Executive Summary

**Date:** 2025-12-31 14:25:52 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 507
**Total Malicious Queries:** 12,835
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 50.0% |
| Egypt | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (Energis UK) | 1 | 50.0% |
| AS8452 (TE Data) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 507
- **Total Malicious Queries:** 12,835
- **Average Blocked/IP:** 253.5
- **Average Malicious/IP:** 6,417.5
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `notify.bugsnag.com` | 276 |
| `gtm.udemy.com` | 24 |
| `ad.doubleclick.net` | 17 |
| `pagead2.googlesyndication.com` | 15 |
| `preferences.cid.samba.tv` | 9 |
| `googleads.g.doubleclick.net` | 8 |
| `bam.nr-data.net` | 8 |
| `e2c63.gcp.gvt2.com` | 6 |
| `e2c79.gcp.gvt2.com` | 6 |
| `aepxlg.adobe.com` | 4 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 6,999 |
| `1-0-0-2.app.ping.computer` | 5,802 |
| `6527093372977557041.4600135884290101376` | 15 |
| `6779138990730360536.1989154302420041672` | 15 |
| `push.apple.com` | 4 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 90.252.125.100 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 160
- **Malicious queries:** 7,003
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `ad.doubleclick.net` (17), `pagead2.googlesyndication.com` (15), `preferences.cid.samba.tv` (9), `googleads.g.doubleclick.net` (8), `bam.nr-data.net` (8)
- **Top malicious domains:** `debug.opendns.com` (6,999), `push.apple.com` (4)

### 156.222.227.198 [Egypt/AS8452]

- **Location:** Cairo, Egypt
- **ISP:** TE Data
- **Blocked queries:** 347
- **Malicious queries:** 5,832
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `notify.bugsnag.com` (276), `gtm.udemy.com` (24), `e2c63.gcp.gvt2.com` (6), `e2c79.gcp.gvt2.com` (6), `aepxlg.adobe.com` (4)
- **Top malicious domains:** `1-0-0-2.app.ping.computer` (5,802), `6527093372977557041.4600135884290101376` (15), `6779138990730360536.1989154302420041672` (15)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,332 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
