### PR TITLE
[uksouth] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,4 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+90.252.125.100 # Auto-blocked [United Kingdom/AS5378] B:209 M:6894 (2026-01-01 14:25:57 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-01 14:25:57 UTC

## 📊 Executive Summary

**Date:** 2026-01-01 14:25:57 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 209
**Total Malicious Queries:** 6,894
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (Energis UK) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 209
- **Total Malicious Queries:** 6,894
- **Average Blocked/IP:** 209.0
- **Average Malicious/IP:** 6,894.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `googleads.g.doubleclick.net` | 26 |
| `pagead2.googlesyndication.com` | 24 |
| `securepubads.g.doubleclick.net` | 20 |
| `preferences.cid.samba.tv` | 12 |
| `logs.netflix.com` | 11 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 6,894 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 90.252.125.100 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 209
- **Malicious queries:** 6,894
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `googleads.g.doubleclick.net` (26), `pagead2.googlesyndication.com` (24), `securepubads.g.doubleclick.net` (20), `preferences.cid.samba.tv` (12), `logs.netflix.com` (11)
- **Top malicious domains:** `debug.opendns.com` (6,894)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,479 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
