### PR TITLE
[uksouth] Auto-block: Add 3 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,6 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+23.88.10.122 # Auto-blocked [Germany/AS24940] B:0 M:12702 (2026-01-03 14:26:16 UTC)
+81.78.94.176 # Auto-blocked [United Kingdom/AS5378] B:268 M:7705 (2026-01-03 14:26:16 UTC)
+54.37.204.38 # Auto-blocked [Germany/AS16276] B:0 M:1401 (2026-01-03 14:26:16 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-03 14:26:16 UTC

## 📊 Executive Summary

**Date:** 2026-01-03 14:26:16 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 3
**Total Blocked Queries:** 268
**Total Malicious Queries:** 21,808
**CIDR Pattern Analysis:** 3 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 3
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Germany | 2 | 66.7% |
| United Kingdom | 1 | 33.3% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS24940 (Hetzner Online GmbH) | 1 | 33.3% |
| AS5378 (Energis UK) | 1 | 33.3% |
| AS16276 (OVH SAS) | 1 | 33.3% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 268
- **Total Malicious Queries:** 21,808
- **Average Blocked/IP:** 89.3
- **Average Malicious/IP:** 7,269.3
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `ad.doubleclick.net` | 33 |
| `region1.google-analytics.com` | 20 |
| `pagead2.googlesyndication.com` | 18 |
| `googleads.g.doubleclick.net` | 17 |
| `ogads-pa.clients6.google.com` | 16 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `diux.mil` | 14,103 |
| `debug.opendns.com` | 7,699 |
| `push.apple.com` | 6 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 23.88.10.122 [Germany/AS24940]

- **Location:** Falkenstein, Germany
- **ISP:** Hetzner Online GmbH
- **Blocked queries:** 0
- **Malicious queries:** 12,702
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `diux.mil` (12,702)

### 54.37.204.38 [Germany/AS16276]

- **Location:** Limburg an der Lahn, Germany
- **ISP:** OVH SAS
- **Blocked queries:** 0
- **Malicious queries:** 1,401
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `diux.mil` (1,401)

### 81.78.94.176 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 268
- **Malicious queries:** 7,705
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `ad.doubleclick.net` (33), `region1.google-analytics.com` (20), `pagead2.googlesyndication.com` (18), `googleads.g.doubleclick.net` (17), `ogads-pa.clients6.google.com` (16)
- **Top malicious domains:** `debug.opendns.com` (7,699), `push.apple.com` (6)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,163 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
