### PR TITLE
[uksouth] Auto-block: Add 4 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,7 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+45.146.8.205 # Auto-blocked [United Kingdom/AS201838] B:26446 M:40 (2026-01-04 14:26:24 UTC)
+81.78.94.176 # Auto-blocked [United Kingdom/AS5378] B:150 M:6444 (2026-01-04 14:26:24 UTC)
+156.216.89.20 # Auto-blocked [Egypt/AS8452] B:857 M:1147 (2026-01-04 14:26:24 UTC)
+185.176.94.91 # Auto-blocked [Germany/AS214309] B:0 M:469 (2026-01-04 14:26:24 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-04 14:26:24 UTC

## 📊 Executive Summary

**Date:** 2026-01-04 14:26:24 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 4
**Total Blocked Queries:** 27,453
**Total Malicious Queries:** 8,100
**CIDR Pattern Analysis:** 4 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 4
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 2 | 50.0% |
| Egypt | 1 | 25.0% |
| Germany | 1 | 25.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS201838 (Community Fibre Limited) | 1 | 25.0% |
| AS5378 (Energis UK) | 1 | 25.0% |
| AS8452 (TE Data) | 1 | 25.0% |
| AS214309 (Aurorix Gaming Solutions Limit) | 1 | 25.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 27,453
- **Total Malicious Queries:** 8,100
- **Average Blocked/IP:** 6,863.2
- **Average Malicious/IP:** 2,025.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `region1.google-analytics.com` | 8,553 |
| `data.eu.pendo.io` | 4,584 |
| `googleads.g.doubleclick.net` | 871 |
| `ad.doubleclick.net` | 828 |
| `prod.tahoe-analytics.publishers.advertising.a2z.com` | 562 |
| `tvx.adgrx.com` | 474 |
| `logs.netflix.com` | 291 |
| `vpn-api.proton.me` | 24 |
| `pagead2.googlesyndication.com` | 23 |
| `securepubads.g.doubleclick.net` | 19 |
| `www.clarity.ms` | 18 |
| `dns11.quad9.net` | 12 |
| `dns.google` | 12 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 7,581 |
| `diux.mil` | 469 |
| `name.debug.opendns.com` | 10 |
| `config.nos.avast.com` | 8 |
| `_aaplcache._tcp.communityfibre.co.uk` | 6 |
| `_aaplcache1._tcp.communityfibre.co.uk` | 6 |
| `_aaplcache4._tcp.communityfibre.co.uk` | 6 |
| `_aaplcache3._tcp.communityfibre.co.uk` | 6 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 45.146.8.205 [United Kingdom/AS201838]

- **Location:** London, United Kingdom
- **ISP:** Community Fibre Limited
- **Blocked queries:** 26,446
- **Malicious queries:** 40
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `region1.google-analytics.com` (8,539), `data.eu.pendo.io` (4,584), `googleads.g.doubleclick.net` (859), `ad.doubleclick.net` (828), `prod.tahoe-analytics.publishers.advertising.a2z.com` (562)
- **Top malicious domains:** `config.nos.avast.com` (8), `_aaplcache._tcp.communityfibre.co.uk` (6), `_aaplcache1._tcp.communityfibre.co.uk` (6), `_aaplcache4._tcp.communityfibre.co.uk` (6), `_aaplcache3._tcp.communityfibre.co.uk` (6)

### 81.78.94.176 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 150
- **Malicious queries:** 6,444
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `pagead2.googlesyndication.com` (23), `securepubads.g.doubleclick.net` (19), `www.clarity.ms` (18), `region1.google-analytics.com` (14), `googleads.g.doubleclick.net` (12)
- **Top malicious domains:** `debug.opendns.com` (6,444)

### 156.216.89.20 [Egypt/AS8452]

- **Location:** Giza, Egypt
- **ISP:** TE Data
- **Blocked queries:** 857
- **Malicious queries:** 1,147
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `tvx.adgrx.com` (474), `logs.netflix.com` (291), `vpn-api.proton.me` (24), `dns11.quad9.net` (12), `dns.google` (12)
- **Top malicious domains:** `debug.opendns.com` (1,137), `name.debug.opendns.com` (10)

### 185.176.94.91 [Germany/AS214309]

- **Location:** Frankfurt am Main, Germany
- **ISP:** Aurorix Gaming Solutions Limited
- **Blocked queries:** 0
- **Malicious queries:** 469
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `diux.mil` (469)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 4,577 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
