### PR TITLE
[uksouth] Auto-block: Add 4 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -97,3 +97,7 @@
 103.81.207.202 # Auto-blocked [Bangladesh/AS136151] B:0 M:747 (2025-12-28 14:12:50 UTC)
 125.30.87.96 # Auto-blocked [Japan/AS2497] B:0 M:382 (2025-12-28 14:12:50 UTC)
 103.81.207.204 # Auto-blocked [Bangladesh/AS136151] B:0 M:305 (2025-12-28 14:12:50 UTC)
+90.247.116.134 # Auto-blocked [United Kingdom/AS5378] B:195 M:7465 (2026-01-06 14:27:06 UTC)
+141.95.72.218 # Auto-blocked [Germany/AS16276] B:0 M:1834 (2026-01-06 14:27:06 UTC)
+81.78.94.176 # Auto-blocked [United Kingdom/AS5378] B:0 M:1476 (2026-01-06 14:27:06 UTC)
+95.181.158.155 # Auto-blocked [Russia/AS43278] B:0 M:482 (2026-01-06 14:27:06 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-06 14:27:06 UTC

## 📊 Executive Summary

**Date:** 2026-01-06 14:27:06 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 4
**Total Blocked Queries:** 195
**Total Malicious Queries:** 11,257
**CIDR Pattern Analysis:** 4 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 4
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 2 | 50.0% |
| Germany | 1 | 25.0% |
| Russia | 1 | 25.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (Vodafone Limited) | 2 | 50.0% |
| AS16276 (OVH SAS) | 1 | 25.0% |
| AS43278 (AZERTA.RU Hosting LLC) | 1 | 25.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 195
- **Total Malicious Queries:** 11,257
- **Average Blocked/IP:** 48.8
- **Average Malicious/IP:** 2,814.2
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `region1.google-analytics.com` | 31 |
| `googleads.g.doubleclick.net` | 23 |
| `tpc.googlesyndication.com` | 17 |
| `ad.doubleclick.net` | 16 |
| `pagead2.googlesyndication.com` | 12 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 8,941 |
| `diux.mil` | 2,316 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 81.78.94.176 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** Energis UK
- **Blocked queries:** 0
- **Malicious queries:** 1,476
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `debug.opendns.com` (1,476)

### 90.247.116.134 [United Kingdom/AS5378]

- **Location:** Borehamwood, United Kingdom
- **ISP:** Vodafone Limited
- **Blocked queries:** 195
- **Malicious queries:** 7,465
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `region1.google-analytics.com` (31), `googleads.g.doubleclick.net` (23), `tpc.googlesyndication.com` (17), `ad.doubleclick.net` (16), `pagead2.googlesyndication.com` (12)
- **Top malicious domains:** `debug.opendns.com` (7,465)

### 95.181.158.155 [Russia/AS43278]

- **Location:** Moscow, Russia
- **ISP:** AZERTA.RU Hosting LLC
- **Blocked queries:** 0
- **Malicious queries:** 482
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `diux.mil` (482)

### 141.95.72.218 [Germany/AS16276]

- **Location:** Limburg an der Lahn, Germany
- **ISP:** OVH SAS
- **Blocked queries:** 0
- **Malicious queries:** 1,834
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `diux.mil` (1,834)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,406 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
