### PR TITLE
[uksouth] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -109,3 +109,5 @@
 141.95.72.218 # Auto-blocked [Germany/AS16276] B:0 M:1834 (2026-01-06 14:27:06 UTC)
 81.78.94.176 # Auto-blocked [United Kingdom/AS5378] B:0 M:1476 (2026-01-06 14:27:06 UTC)
 95.181.158.155 # Auto-blocked [Russia/AS43278] B:0 M:482 (2026-01-06 14:27:06 UTC)
+156.216.171.204 # Auto-blocked [Egypt/AS8452] B:65 M:1240 (2026-01-07 14:27:20 UTC)
+156.214.161.84 # Auto-blocked [Egypt/AS8452] B:0 M:284 (2026-01-07 14:27:20 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-07 14:27:20 UTC

## 📊 Executive Summary

**Date:** 2026-01-07 14:27:20 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 65
**Total Malicious Queries:** 1,524
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Egypt | 2 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS8452 (TE Data) | 2 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 65
- **Total Malicious Queries:** 1,524
- **Average Blocked/IP:** 32.5
- **Average Malicious/IP:** 762.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `vpn-api.proton.me` | 21 |
| `telemetry.individual.githubcopilot.com` | 9 |
| `googleads.g.doubleclick.net` | 3 |
| `dns11.quad9.net` | 3 |
| `dns.google` | 3 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 1,520 |
| `name.debug.opendns.com` | 4 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **90.247.116.134** [United Kingdom/AS5378] - 1594 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 156.214.161.84 [Egypt/AS8452]

- **Location:** Giza, Egypt
- **ISP:** TE Data
- **Blocked queries:** 0
- **Malicious queries:** 284
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `debug.opendns.com` (284)

### 156.216.171.204 [Egypt/AS8452]

- **Location:** Giza, Egypt
- **ISP:** TE Data
- **Blocked queries:** 65
- **Malicious queries:** 1,240
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `vpn-api.proton.me` (21), `telemetry.individual.githubcopilot.com` (9), `googleads.g.doubleclick.net` (3), `dns11.quad9.net` (3), `dns.google` (3)
- **Top malicious domains:** `debug.opendns.com` (1,236), `name.debug.opendns.com` (4)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,172 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
