### PR TITLE
[southeastasia] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -115,3 +115,5 @@
 83.106.94.60 # Auto-blocked [United Kingdom/AS5378] B:370 M:3764 (2026-01-08 14:27:58 UTC)
 156.214.104.147 # Auto-blocked [Egypt/AS8452] B:531 M:514 (2026-01-08 14:27:58 UTC)
 156.216.51.168 # Auto-blocked [Egypt/AS8452] B:109 M:446 (2026-01-08 14:27:58 UTC)
+103.99.129.60 # Auto-blocked [Bangladesh/AS136937] B:0 M:1897 (2026-01-10 14:17:27 UTC)
+103.58.92.38 # Auto-blocked [Bangladesh/AS134201] B:0 M:287 (2026-01-10 14:17:27 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-10 14:17:27 UTC

## 📊 Executive Summary

**Date:** 2026-01-10 14:17:27 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 2,184
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Bangladesh | 2 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS136937 (Chittagong University of Engin) | 1 | 50.0% |
| AS134201 (Metaphor Digital Media) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 2,184
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 1,092.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `70-4c-a5.a.o.e5.sk` | 16 |
| `t.213891.xyz` | 15 |
| `tracker.torrent.eu.org` | 15 |
| `d40969.acod.regrucolo.ru` | 15 |
| `tracker.internetwarriors.net` | 10 |
| `public.popcorn-tracker.org` | 10 |
| `b4-8c-9d.a.o.e5.sk` | 6 |
| `98-03-8e.a.o.e5.sk` | 6 |
| `14-13-33.a.o.e5.sk` | 4 |
| `ee-da-d1.a.o.e5.sk` | 2 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 103.58.92.38 [Bangladesh/AS134201]

- **Location:** Kāfrul, Bangladesh
- **ISP:** Metaphor Digital Media
- **Blocked queries:** 0
- **Malicious queries:** 287
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `t.213891.xyz` (15), `tracker.torrent.eu.org` (15), `d40969.acod.regrucolo.ru` (15), `tracker.internetwarriors.net` (10), `public.popcorn-tracker.org` (10)

### 103.99.129.60 [Bangladesh/AS136937]

- **Location:** Raojān, Bangladesh
- **ISP:** Chittagong University of Engineering & Technology
- **Blocked queries:** 0
- **Malicious queries:** 1,897
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `70-4c-a5.a.o.e5.sk` (16), `b4-8c-9d.a.o.e5.sk` (6), `98-03-8e.a.o.e5.sk` (6), `14-13-33.a.o.e5.sk` (4), `ee-da-d1.a.o.e5.sk` (2)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,880 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** southeastasia
