### PR TITLE
(add) - missing blacklist URLs for anti-islamic and lgbt

### DIFF
--- a/blacklist_urls.txt
+++ b/blacklist_urls.txt
@@ -73,9 +73,11 @@
 # Kahf custom blacklist
 [misc] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/blacklist_domains.txt
 [adult] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/adult.txt
+[anti-islamic] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/anti-islamic.txt
 [dating] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/dating.txt
 [gambling] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/gambling.txt
-[violence] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/violence.txt
+[lgbt] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/lgbt.txt
 [malware] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/malware.txt
 [piracy] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/piracy.txt
 [social] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/social.txt
+[violence] https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-blacklist/violence.txt


### PR DESCRIPTION
## Summary
- Add missing blacklist file references to `blacklist_urls.txt`
- Ensures all files in `kahf-custom-blacklist/` are included in the fetch list

## Changes
Added 2 missing blacklist URLs:
- `[anti-islamic]` - blocks anti-Islamic content
- `[lgbt]` - blocks LGBT content

Also reorganized entries alphabetically for consistency (moved `violence` to end).

## Before vs After

| File | Before | After |
|------|--------|-------|
| anti-islamic.txt | Not included | ✅ Included |
| lgbt.txt | Not included | ✅ Included |

## Test plan
- [ ] Verify all blacklist files are fetched correctly
- [ ] Confirm new categories appear in the filtering system