### PR TITLE
[southeastasia] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -118,3 +118,5 @@
 67.182.23.187 # Auto-blocked [United States/AS7922] B:23289 M:14 (2026-01-11 14:28:41 UTC)
 81.78.84.151 # Auto-blocked [United Kingdom/AS5378] B:540 M:3802 (2026-01-11 14:28:41 UTC)
 156.216.175.106 # Auto-blocked [Egypt/AS8452] B:526 M:1216 (2026-01-11 14:28:41 UTC)
+103.99.129.60 # Auto-blocked [Bangladesh/AS136937] B:0 M:995 (2026-01-12 14:18:05 UTC)
+119.40.93.194 # Auto-blocked [Bangladesh/AS24122] B:0 M:270 (2026-01-12 14:18:05 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-12 14:18:05 UTC

## 📊 Executive Summary

**Date:** 2026-01-12 14:18:05 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,265
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Bangladesh | 2 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS136937 (Chittagong University of Engin) | 1 | 50.0% |
| AS24122 (BDCOM Online Limited) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,265
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 632.5
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `google.com` | 162 |
| `_aaplcache2._tcp.mshome.net` | 28 |
| `_aaplcache3._tcp.mshome.net` | 28 |
| `_aaplcache1._tcp.mshome.net` | 18 |
| `_aaplcache._tcp.mshome.net` | 17 |
| `70-4c-a5.a.o.e5.sk` | 8 |
| `98-03-8e.a.o.e5.sk` | 6 |
| `b6-3f-aa.a.o.e5.sk` | 4 |
| `5a-c0-5b.a.o.e5.sk` | 4 |
| `b4-8c-9d.a.o.e5.sk` | 4 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 103.99.129.60 [Bangladesh/AS136937]

- **Location:** Raojān, Bangladesh
- **ISP:** Chittagong University of Engineering & Technology
- **Blocked queries:** 0
- **Malicious queries:** 995
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `70-4c-a5.a.o.e5.sk` (8), `98-03-8e.a.o.e5.sk` (6), `b6-3f-aa.a.o.e5.sk` (4), `5a-c0-5b.a.o.e5.sk` (4), `b4-8c-9d.a.o.e5.sk` (4)

### 119.40.93.194 [Bangladesh/AS24122]

- **Location:** Dhaka, Bangladesh
- **ISP:** BDCOM Online Limited
- **Blocked queries:** 0
- **Malicious queries:** 270
- **Detected on nodes:** southeastasia-frontend-0
- **Top malicious domains:** `google.com` (162), `_aaplcache2._tcp.mshome.net` (28), `_aaplcache3._tcp.mshome.net` (28), `_aaplcache1._tcp.mshome.net` (18), `_aaplcache._tcp.mshome.net` (17)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,880 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** southeastasia
