### PR TITLE
(add) - bangladeshi websites

### DIFF
--- a/whitelist_urls.txt
+++ b/whitelist_urls.txt
@@ -17,8 +17,8 @@ https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom
 # https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/apple.txt
 # https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/meta.txt
 
-# # Regional
-# https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/bangladesh.txt
+# Regional
+https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/bangladesh.txt
 # https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/chinese-tech.txt
 # https://raw.githubusercontent.com/KahfGuard/PublicConfiguration/main/kahf-custom-whitelist/russian-tech.txt
 


### PR DESCRIPTION
Currently Blocked
-------------------

citybank.com.bd
gov.bd
ju.ac.bd
moe.gov.bd
mtb.com.bd
nb.gov.bd
nsu.edu.bd
police.gov.bd
pubalibank.com.bd
rocket.com.bd
upay.com.bd