### PR TITLE
[uksouth] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -133,3 +133,5 @@
 187.102.193.28 # Auto-blocked [Chile/AS264827] B:0 M:260 (2026-01-14 14:29:07 UTC)
 187.102.193.48 # Auto-blocked [Chile/AS264827] B:0 M:258 (2026-01-14 14:29:07 UTC)
 187.102.193.32 # Auto-blocked [Chile/AS264827] B:0 M:254 (2026-01-14 14:29:07 UTC)
+83.106.91.5 # Auto-blocked [United Kingdom/AS5378] B:0 M:7147 (2026-01-18 14:31:16 UTC)
+72.180.114.209 # Auto-blocked [United States/AS11427] B:0 M:354 (2026-01-18 14:31:16 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-18 14:31:16 UTC

## 📊 Executive Summary

**Date:** 2026-01-18 14:31:16 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 7,501
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 50.0% |
| United States | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (VODAFONE) | 1 | 50.0% |
| AS11427 (Charter Communications) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 7,501
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 3,750.5
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 7,139 |
| `push.apple.com` | 362 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 72.180.114.209 [United States/AS11427]

- **Location:** Cedar Park, United States
- **ISP:** Charter Communications
- **Blocked queries:** 0
- **Malicious queries:** 354
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `push.apple.com` (354)

### 83.106.91.5 [United Kingdom/AS5378]

- **Location:** Barnet, United Kingdom
- **ISP:** VODAFONE
- **Blocked queries:** 0
- **Malicious queries:** 7,147
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `debug.opendns.com` (7,139), `push.apple.com` (8)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,378 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
