### PR TITLE
[southeastasia] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -141,3 +141,4 @@
 103.184.173.38 # Auto-blocked [Bangladesh/AS149653] B:0 M:516 (2026-01-18 14:19:58 UTC)
 150.31.52.151 # Auto-blocked [Japan/AS2497] B:0 M:440 (2026-01-18 14:19:58 UTC)
 72.180.114.209 # Auto-blocked [United States/AS11427] B:0 M:354 (2026-01-18 14:31:16 UTC)
+119.40.93.194 # Auto-blocked [Bangladesh/AS24122] B:760 M:262 (2026-01-20 14:20:05 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-20 14:20:05 UTC

## 📊 Executive Summary

**Date:** 2026-01-20 14:20:05 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 760
**Total Malicious Queries:** 262
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Bangladesh | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS24122 (BDCOM Online Limited) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 760
- **Total Malicious Queries:** 262
- **Average Blocked/IP:** 760.0
- **Average Malicious/IP:** 262.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `s.xlgmedia.com` | 72 |
| `www.google-analytics.com` | 70 |
| `googleads.g.doubleclick.net` | 48 |
| `antpeak.com` | 40 |
| `hibchr.com` | 37 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `google.com` | 218 |
| `_aaplcache._tcp.mshome.net` | 10 |
| `_aaplcache4._tcp.mshome.net` | 10 |
| `_aaplcache1._tcp.mshome.net` | 10 |
| `_aaplcache2._tcp.mshome.net` | 7 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 119.40.93.194 [Bangladesh/AS24122]

- **Location:** Dhaka, Bangladesh
- **ISP:** BDCOM Online Limited
- **Blocked queries:** 760
- **Malicious queries:** 262
- **Detected on nodes:** southeastasia-frontend-0
- **Top blocked domains:** `s.xlgmedia.com` (72), `www.google-analytics.com` (70), `googleads.g.doubleclick.net` (48), `antpeak.com` (40), `hibchr.com` (37)
- **Top malicious domains:** `google.com` (218), `_aaplcache._tcp.mshome.net` (10), `_aaplcache4._tcp.mshome.net` (10), `_aaplcache1._tcp.mshome.net` (10), `_aaplcache2._tcp.mshome.net` (7)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,683 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** southeastasia
