### PR TITLE
[uksouth] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -141,3 +141,4 @@
 103.184.173.38 # Auto-blocked [Bangladesh/AS149653] B:0 M:516 (2026-01-18 14:19:58 UTC)
 150.31.52.151 # Auto-blocked [Japan/AS2497] B:0 M:440 (2026-01-18 14:19:58 UTC)
 72.180.114.209 # Auto-blocked [United States/AS11427] B:0 M:354 (2026-01-18 14:31:16 UTC)
+90.243.33.157 # Auto-blocked [United Kingdom/AS5378] B:523 M:341 (2026-01-24 14:31:50 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-01-24 14:31:50 UTC

## 📊 Executive Summary

**Date:** 2026-01-24 14:31:50 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 523
**Total Malicious Queries:** 341
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (Vodafone Group PLC) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 523
- **Total Malicious Queries:** 341
- **Average Blocked/IP:** 523.0
- **Average Malicious/IP:** 341.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `www.google-analytics.com` | 67 |
| `www.googletagmanager.com` | 60 |
| `_dns.resolver.arpa` | 54 |
| `dns.google` | 45 |
| `googleads.g.doubleclick.net` | 44 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 341 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 90.243.33.157 [United Kingdom/AS5378]

- **Location:** Edgware, United Kingdom
- **ISP:** Vodafone Group PLC
- **Blocked queries:** 523
- **Malicious queries:** 341
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `www.google-analytics.com` (67), `www.googletagmanager.com` (60), `_dns.resolver.arpa` (54), `dns.google` (45), `googleads.g.doubleclick.net` (44)
- **Top malicious domains:** `debug.opendns.com` (341)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,437 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
