### PR TITLE
[uksouth] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -1,0 +1,1 @@
+83.106.70.27 # Auto-blocked [United Kingdom/AS5378] B:526 M:3800 (2026-02-12 14:34:54 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-02-12 14:34:54 UTC

## 📊 Executive Summary

**Date:** 2026-02-12 14:34:54 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 526
**Total Malicious Queries:** 3,800
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (VODAFONE) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 526
- **Total Malicious Queries:** 3,800
- **Average Blocked/IP:** 526.0
- **Average Malicious/IP:** 3,800.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `region1.google-analytics.com` | 125 |
| `www.google-analytics.com` | 124 |
| `_dns.resolver.arpa` | 95 |
| `dns.google` | 59 |
| `googleads.g.doubleclick.net` | 30 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 3,800 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 83.106.70.27 [United Kingdom/AS5378]

- **Location:** City of Westminster, United Kingdom
- **ISP:** VODAFONE
- **Blocked queries:** 526
- **Malicious queries:** 3,800
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `region1.google-analytics.com` (125), `www.google-analytics.com` (124), `_dns.resolver.arpa` (95), `dns.google` (59), `googleads.g.doubleclick.net` (30)
- **Top malicious domains:** `debug.opendns.com` (3,800)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,452 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
