### PR TITLE
[uksouth] Auto-block: Add 3 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -1,0 +1,3 @@
+83.106.70.27 # Auto-blocked [United Kingdom/AS5378] B:145 M:3689 (2026-02-16 14:35:35 UTC)
+142.120.149.188 # Auto-blocked [Canada/AS577] B:61 M:645 (2026-02-16 14:35:35 UTC)
+109.250.28.121 # Auto-blocked [Germany/AS8881] B:0 M:301 (2026-02-16 14:35:35 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-02-16 14:35:35 UTC

## 📊 Executive Summary

**Date:** 2026-02-16 14:35:35 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 3
**Total Blocked Queries:** 206
**Total Malicious Queries:** 4,635
**CIDR Pattern Analysis:** 3 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 3
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 33.3% |
| Canada | 1 | 33.3% |
| Germany | 1 | 33.3% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (VODAFONE) | 1 | 33.3% |
| AS577 (Bell Canada) | 1 | 33.3% |
| AS8881 (Vt-dynamicpool RMS) | 1 | 33.3% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 206
- **Total Malicious Queries:** 4,635
- **Average Blocked/IP:** 68.7
- **Average Malicious/IP:** 1,545.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `googleads.g.doubleclick.net` | 27 |
| `sync.hydra.opendns.com` | 26 |
| `_dns.resolver.arpa` | 15 |
| `tr.snapchat.com` | 11 |
| `stats.g.doubleclick.net` | 8 |
| `ogads-pa.clients6.google.com` | 6 |
| `ad.doubleclick.net` | 6 |
| `www.google-analytics.com` | 4 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 4,334 |
| `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` | 301 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 83.106.70.27 [United Kingdom/AS5378]

- **Location:** Brent, United Kingdom
- **ISP:** VODAFONE
- **Blocked queries:** 145
- **Malicious queries:** 3,689
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `googleads.g.doubleclick.net` (27), `sync.hydra.opendns.com` (16), `tr.snapchat.com` (11), `_dns.resolver.arpa` (9), `stats.g.doubleclick.net` (8)
- **Top malicious domains:** `debug.opendns.com` (3,689)

### 109.250.28.121 [Germany/AS8881]

- **Location:** Karlsruhe, Germany
- **ISP:** Vt-dynamicpool RMS
- **Blocked queries:** 0
- **Malicious queries:** 301
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` (301)

### 142.120.149.188 [Canada/AS577]

- **Location:** Mississauga, Canada
- **ISP:** Bell Canada
- **Blocked queries:** 61
- **Malicious queries:** 645
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `sync.hydra.opendns.com` (10), `_dns.resolver.arpa` (6), `ogads-pa.clients6.google.com` (6), `ad.doubleclick.net` (6), `www.google-analytics.com` (4)
- **Top malicious domains:** `debug.opendns.com` (645)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,467 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
