### PR TITLE
[uksouth] Auto-block: Add 3 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -1,0 +1,3 @@
+83.106.70.27 # Auto-blocked [United Kingdom/AS5378] B:21 M:3912 (2026-02-17 14:35:41 UTC)
+142.120.149.188 # Auto-blocked [Canada/AS577] B:29 M:1107 (2026-02-17 14:35:41 UTC)
+109.250.29.219 # Auto-blocked [Germany/AS8881] B:0 M:972 (2026-02-17 14:35:41 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-02-17 14:35:41 UTC

## 📊 Executive Summary

**Date:** 2026-02-17 14:35:41 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 3
**Total Blocked Queries:** 50
**Total Malicious Queries:** 5,991
**CIDR Pattern Analysis:** 3 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 3
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| United Kingdom | 1 | 33.3% |
| Canada | 1 | 33.3% |
| Germany | 1 | 33.3% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS5378 (VODAFONE) | 1 | 33.3% |
| AS577 (Bell Canada) | 1 | 33.3% |
| AS8881 (Vt-dynamicpool RMS) | 1 | 33.3% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 50
- **Total Malicious Queries:** 5,991
- **Average Blocked/IP:** 16.7
- **Average Malicious/IP:** 1,997.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `googleads.g.doubleclick.net` | 7 |
| `combine.urbanairship.com` | 4 |
| `ade.googlesyndication.com` | 4 |
| `ad.doubleclick.net` | 4 |
| `pagead2.googlesyndication.com` | 4 |
| `rt.applovin.com` | 4 |
| `config.inmobi.com` | 3 |
| `config.ads.vungle.com` | 2 |
| `sf16-static.i18n-pglstatp.com` | 2 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 4,999 |
| `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` | 972 |
| `rider.android.mobile-config.uber.com` | 8 |
| `push.apple.com` | 8 |
| `name.debug.opendns.com` | 4 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 83.106.70.27 [United Kingdom/AS5378]

- **Location:** Brent, United Kingdom
- **ISP:** VODAFONE
- **Blocked queries:** 21
- **Malicious queries:** 3,912
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `combine.urbanairship.com` (4), `googleads.g.doubleclick.net` (4), `ade.googlesyndication.com` (4), `ad.doubleclick.net` (4), `pagead2.googlesyndication.com` (4)
- **Top malicious domains:** `debug.opendns.com` (3,896), `rider.android.mobile-config.uber.com` (8), `push.apple.com` (8)

### 109.250.29.219 [Germany/AS8881]

- **Location:** Karlsruhe, Germany
- **ISP:** Vt-dynamicpool RMS
- **Blocked queries:** 0
- **Malicious queries:** 972
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` (972)

### 142.120.149.188 [Canada/AS577]

- **Location:** Mississauga, Canada
- **ISP:** Bell Canada
- **Blocked queries:** 29
- **Malicious queries:** 1,107
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `rt.applovin.com` (4), `config.inmobi.com` (3), `googleads.g.doubleclick.net` (3), `config.ads.vungle.com` (2), `sf16-static.i18n-pglstatp.com` (2)
- **Top malicious domains:** `debug.opendns.com` (1,103), `name.debug.opendns.com` (4)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 3,719 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
