### PR TITLE
Fix Firefox DoH bypass: router config + expanded DNS blocklist

### DIFF
--- a/lists/block/dns.txt
+++ b/lists/block/dns.txt
@@ -1,10 +1,11 @@
 # KahfGuard DNS-over-HTTPS Bypass Blocklist
-
 # Cloudflare DNS
+1dot1dot1dot1.cloudflare-dns.com
 chrome.cloudflare-dns.com
+cloudflare-dns.com
 dns.cloudflare.com
 mozilla.cloudflare-dns.com
-
+one.one.one.one
 # NextDNS
 chromium.dns.nextdns.io
 dns.nextdns.io
@@ -13,21 +14,31 @@ dns2.nextdns.io
 edge.nextdns.io
 firefox.dns.nextdns.io
 steering.nextdns.io
-
 # Google DNS
 dns.google
-
+dns.google.com
+dns64.dns.google
 # Quad9
 dns.quad9.net
-
+dns10.quad9.net
+dns11.quad9.net
+dns9.quad9.net
 # AdGuard DNS
+dns-family.adguard.com
+dns-unfiltered.adguard.com
 dns.adguard.com
-
 # CleanBrowsing
 doh.cleanbrowsing.org
-
 # OpenDNS (Cisco)
 doh.opendns.com
-
-# Apple Private Relay
+# Apple Private Relay / iCloud DoH
+doh.dns.apple.com
 gateway.fe2.apple-dns.net
+mask-api.icloud.com
+mask.icloud.com
+# ControlD
+freedns.controld.com
+# Mullvad
+adblock.dns.mullvad.net
+base.dns.mullvad.net
+dns.mullvad.net

--- a/router-config/forwarder-router-dns.rsc
+++ b/router-config/forwarder-router-dns.rsc
@@ -1,12 +1,32 @@
-# =============================================
-#  Distribution Router - DNS Interception
-# =============================================
+# =====================================================================
+#  Distribution Router — DNS Filtering Enforcement
+# =====================================================================
 #
-#  Port 53         →  Forward to core router
-#  Port 853, 443u  →  Allow only to KAHF, drop rest
+#  BYPASS VECTORS AND MITIGATIONS:
+#  ──────────────────────────────────────────────────────────────────
+#  Vector              Port        Protocol    Mitigation
+#  ──────────────────────────────────────────────────────────────────
+#  Plain DNS           53   TCP/UDP            NAT redirect → forwarder
+#  DNS-over-TLS (DoT)  853  TCP                DROP (except KAHF)
+#  DNS-over-QUIC (DoQ) 853  UDP                DROP (except KAHF)
+#  QUIC/HTTP3          443  UDP                DROP (except KAHF)
+#  DoH via HTTP/2      443  TCP                DROP to known DoH IPs
+#  ──────────────────────────────────────────────────────────────────
 #
-#  Usage   : /import file=dist-router-dns.rsc
-# =============================================
+#  PERMISSIONS:
+#  ──────────────────────────────────────────────────────────────────
+#  Bypass_Safe       = KahfGuard server IPs (encrypted DNS allowed TO)
+#  Safe_Package_IPs  = Client IPs that must be filtered (filtered FROM)
+#  DoH_Providers     = Known DoH provider IPs (always blocked for clients)
+#  ──────────────────────────────────────────────────────────────────
+#
+#  IMPORTANT: Rules 853/443 use DROP (firewall filter), NOT dst-nat.
+#  NAT redirect fails for encrypted protocols — TLS/QUIC validates the
+#  server certificate, so redirecting to a different server causes a
+#  silent TLS handshake failure, NOT a block.
+#
+#  Usage: /import file=forwarder-router-dns.rsc
+# =====================================================================
 
 
 # ===== CHANGE THESE PER ISP =====
@@ -19,14 +39,43 @@
 :local notSafeList ("!" . $safeList)
 
 
-# ----- KAHF Servers -----
+# ─────────────────────────────────
+#  Address Lists
+# ─────────────────────────────────
 
+# KahfGuard servers — encrypted DNS is ALLOWED to these
 /ip firewall address-list
 add list=$safeList address=203.190.10.112/28  comment="KAHF-BDIX"
 add list=$safeList address=40.120.32.128/26   comment="KAHF-Azure"
 
+# Known DoH provider IPs — blocked on TCP 443 to prevent browser DoH bypass
+# These are dedicated DNS anycast IPs, NOT shared with CDN/web services
+/ip firewall address-list
+add list=DoH_Providers address=1.1.1.1         comment="Cloudflare DNS"
+add list=DoH_Providers address=1.0.0.1         comment="Cloudflare DNS"
+add list=DoH_Providers address=8.8.8.8         comment="Google DNS"
+add list=DoH_Providers address=8.8.4.4         comment="Google DNS"
+add list=DoH_Providers address=9.9.9.9         comment="Quad9"
+add list=DoH_Providers address=149.112.112.112 comment="Quad9"
+add list=DoH_Providers address=9.9.9.10        comment="Quad9 unfiltered"
+add list=DoH_Providers address=149.112.112.10  comment="Quad9 unfiltered"
+add list=DoH_Providers address=208.67.222.222  comment="OpenDNS"
+add list=DoH_Providers address=208.67.220.220  comment="OpenDNS"
+add list=DoH_Providers address=94.140.14.14    comment="AdGuard"
+add list=DoH_Providers address=94.140.15.15    comment="AdGuard"
+add list=DoH_Providers address=45.90.28.0      comment="NextDNS"
+add list=DoH_Providers address=45.90.30.0      comment="NextDNS"
+add list=DoH_Providers address=185.228.168.9   comment="CleanBrowsing"
+add list=DoH_Providers address=185.228.169.9   comment="CleanBrowsing"
+add list=DoH_Providers address=76.76.2.0       comment="ControlD"
+add list=DoH_Providers address=76.76.10.0      comment="ControlD"
+add list=DoH_Providers address=194.242.2.2     comment="Mullvad"
 
-# ----- DNS (port 53) → Forwarder -----
+
+# ─────────────────────────────────
+#  NAT: Plain DNS (port 53) → Forwarder
+# ─────────────────────────────────
+# Only redirects clients in $clientList. Other users keep their own DNS.
 
 /ip firewall nat
 add chain=dstnat protocol=udp dst-port=53 src-address-list=$clientList \
@@ -35,12 +84,31 @@ add chain=dstnat protocol=tcp dst-port=53 src-address-list=$clientList \
     action=dst-nat to-addresses=$forwarder to-ports=53 comment="DNS to Core: TCP"
 
 
-# ----- Encrypted DNS → KAHF only, drop rest -----
+# ─────────────────────────────────
+#  FILTER: Encrypted DNS → DROP (except KAHF)
+# ─────────────────────────────────
+# Uses firewall filter (DROP), NOT NAT redirect.
+# NAT redirect of encrypted protocols fails silently (TLS cert mismatch).
 
 /ip firewall filter
-add chain=forward protocol=tcp dst-port=853 dst-address-list=$notSafeList action=drop comment="Drop DoT"
-add chain=forward protocol=udp dst-port=853 dst-address-list=$notSafeList action=drop comment="Drop DoQ"
-add chain=forward protocol=udp dst-port=443 dst-address-list=$notSafeList action=drop comment="Drop QUIC"
+add chain=forward protocol=tcp dst-port=853 src-address-list=$clientList \
+    dst-address-list=$notSafeList action=drop comment="Drop DoT"
+add chain=forward protocol=udp dst-port=853 src-address-list=$clientList \
+    dst-address-list=$notSafeList action=drop comment="Drop DoQ"
+add chain=forward protocol=udp dst-port=443 src-address-list=$clientList \
+    dst-address-list=$notSafeList action=drop comment="Drop QUIC/DoH3"
 
 
-:log info "Dist DNS: Done. Port 53->core($forwarder), 853/443u->KAHF only"
+# ─────────────────────────────────
+#  FILTER: DoH over HTTP/2 (TCP 443) → DROP to known providers
+# ─────────────────────────────────
+# TCP 443 can't be blanket-blocked (breaks all HTTPS).
+# Instead, block TCP 443 to known DoH provider IPs specifically.
+# These are dedicated DNS anycast IPs — blocking them does NOT affect
+# web browsing (CDN/websites use different IP ranges).
+
+add chain=forward protocol=tcp dst-port=443 src-address-list=$clientList \
+    dst-address-list=DoH_Providers action=drop comment="Drop DoH to known providers"
+
+
+:log info "KahfGuard DNS enforcement loaded: 53->$forwarder, 853/443u->KAHF only, DoH IPs blocked"


### PR DESCRIPTION
## Summary
- Rewrite router config with `DoH_Providers` address list to DROP TCP 443 to known DoH provider IPs
- Add `src-address-list` scoping so encrypted DNS rules only affect filtered clients
- Expand `dns.txt` with missing providers: Google (`dns.google.com`, `dns64.dns.google`), Apple (`doh.dns.apple.com`, `mask.icloud.com`), Quad9 subdomains, AdGuard variants, ControlD, Mullvad

## Context
Firefox auto-enables DoH by checking `use-application-dns.net`. The NXDOMAIN fix is in the dns repo (MR !181). This PR covers the network-level enforcement: router firewall rules and domain blocklist expansion.

## Key change: DROP not dst-nat
The old router config used only firewall filter for 853/443u. The new config adds a `DoH_Providers` IP address list to also DROP TCP 443 to known DoH resolver IPs (Cloudflare, Google, Quad9, etc.) — these are dedicated anycast IPs that don't serve web content.