### PR TITLE
[uksouth] Auto-block: Add 1 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -1,3 +1,4 @@
 83.106.70.27 # Auto-blocked [United Kingdom/AS5378] B:21 M:3912 (2026-02-17 14:35:41 UTC)
 142.120.149.188 # Auto-blocked [Canada/AS577] B:29 M:1107 (2026-02-17 14:35:41 UTC)
 109.250.29.219 # Auto-blocked [Germany/AS8881] B:0 M:972 (2026-02-17 14:35:41 UTC)
+61.8.135.87 # Auto-blocked [Germany/AS8881] B:5 M:470 (2026-02-18 14:35:42 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-02-18 14:35:42 UTC

## 📊 Executive Summary

**Date:** 2026-02-18 14:35:42 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 1
**Total Blocked Queries:** 5
**Total Malicious Queries:** 470
**CIDR Pattern Analysis:** 1 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 1
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)
**Already Blacklisted (still active):** 1 ⚠️

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Germany | 1 | 100.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS8881 (1&1 Versatel Deutschland GmbH) | 1 | 100.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 5
- **Total Malicious Queries:** 470
- **Average Blocked/IP:** 5.0
- **Average Malicious/IP:** 470.0
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## 🎯 Top Blocked Domains (Queried by Attackers)

| Domain | Query Count |
|--------|-------------|
| `region1.app-analytics-services.com` | 3 |
| `app-analytics-services.com` | 2 |

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` | 470 |


### ⚠️ WARNING: Already-Blacklisted IPs Still Active

The following IPs are already in the blacklist but are still making malicious queries. This indicates the IP blacklist may not be properly applied on DNS nodes.

- **142.120.149.188** [Canada/AS577] - 492 malicious queries

**Action Required:** Investigate why blacklist is not blocking these IPs.

---

## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 61.8.135.87 [Germany/AS8881]

- **Location:** Frankfurt am Main, Germany
- **ISP:** 1&1 Versatel Deutschland GmbH
- **Blocked queries:** 5
- **Malicious queries:** 470
- **Detected on nodes:** uksouth-frontend-0
- **Top blocked domains:** `region1.app-analytics-services.com` (3), `app-analytics-services.com` (2)
- **Top malicious domains:** `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` (470)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Investigate** why already-blacklisted IPs are still active
3. **Merge** this PR to apply new blocks
4. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
5. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,856 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
