### PR TITLE
[uksouth] Auto-block: Add 2 malicious IPs (cluster-wide analysis)

### DIFF
--- a/ip_blacklist.txt
+++ b/ip_blacklist.txt
@@ -2,3 +2,5 @@
 142.120.149.188 # Auto-blocked [Canada/AS577] B:29 M:1107 (2026-02-17 14:35:41 UTC)
 109.250.29.219 # Auto-blocked [Germany/AS8881] B:0 M:972 (2026-02-17 14:35:41 UTC)
 61.8.135.87 # Auto-blocked [Germany/AS8881] B:5 M:470 (2026-02-18 14:35:42 UTC)
+64.231.21.96 # Auto-blocked [Canada/AS577] B:0 M:974 (2026-02-20 14:35:43 UTC)
+61.8.130.162 # Auto-blocked [Germany/AS8881] B:0 M:553 (2026-02-20 14:35:43 UTC)


### PR DESCRIPTION
# 🛡️ Auto-Block Report - 2026-02-20 14:35:43 UTC

## 📊 Executive Summary

**Date:** 2026-02-20 14:35:43 UTC
**Analysis Coverage:** 2/2 nodes
**Individual IPs to Block:** 2
**Total Blocked Queries:** 0
**Total Malicious Queries:** 1,527
**CIDR Pattern Analysis:** 2 ranges identified (0 IPs belong to coordinated ranges)
**Isolated IPs:** 2
**Coordinated Ranges:** 0 (CIDR shown for pattern recognition only)

⚠️ **Important:** This PR blocks individual IPs only. CIDR blocks below are shown for attack pattern visualization and do not block undetected IPs within ranges.

## 🌍 Geographic Distribution

| Country | IP Count | Percentage |
|---------|----------|------------|
| Canada | 1 | 50.0% |
| Germany | 1 | 50.0% |

## 🏢 ASN Distribution

| ASN | IP Count | Percentage |
|-----|----------|------------|
| AS577 (Bell Canada) | 1 | 50.0% |
| AS8881 (1&1 Versatel Deutschland GmbH) | 1 | 50.0% |

## 📈 Attack Statistics

- **Total Blocked Queries:** 0
- **Total Malicious Queries:** 1,527
- **Average Blocked/IP:** 0.0
- **Average Malicious/IP:** 763.5
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250

## ⚠️ Top Malicious Query Domains (Suspicious Patterns)

| Domain | Malicious Query Count |
|--------|----------------------|
| `debug.opendns.com` | 959 |
| `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` | 553 |
| `name.debug.opendns.com` | 15 |


## 🔒 New IPs to Block (CIDR Patterns for Analysis)

The following shows attack patterns grouped by CIDR ranges. **Only individual IPs are blocked** (no undetected IPs within CIDR ranges).

### 61.8.130.162 [Germany/AS8881]

- **Location:** Frankfurt am Main, Germany
- **ISP:** 1&1 Versatel Deutschland GmbH
- **Blocked queries:** 0
- **Malicious queries:** 553
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `c5e606714d007658-00000000f332273a._matter._tcp.default.service.arpa` (553)

### 64.231.21.96 [Canada/AS577]

- **Location:** Mississauga, Canada
- **ISP:** Bell Canada
- **Blocked queries:** 0
- **Malicious queries:** 974
- **Detected on nodes:** uksouth-frontend-0
- **Top malicious domains:** `debug.opendns.com` (959), `name.debug.opendns.com` (15)


---

## 💡 Recommendations

---

## 📋 Next Steps

1. **Review** the IPs and their activity patterns
2. **Merge** this PR to apply blocks
3. **Sync** blocklist: `bash manage_ip_lists.sh --kahf-only` on all nodes
4. **Verify** blocks are effective within 5 minutes

---

🤖 **Auto-generated by Central Malicious IP Monitor**

- **Report Size:** 2,504 characters (limit: 65,536)
- **Detection Thresholds:** Blocked ≥ 20,000, Malicious ≥ 250
- **Analysis Period:** Last query data from monitored nodes
- **Nodes Analyzed:** 2/2
- **Region:** uksouth
